### PR TITLE
Fixed android.os.FileUriExposedException file:///storage/emulated/0/M…

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -237,7 +237,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     if (pickVideo) {
       requestCode = REQUEST_LAUNCH_VIDEO_CAPTURE;
       cameraIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
-      Uri fileUri = getOutputMediaFile(MEDIA_TYPE_VIDEO);  // create a file to save the video in specific folder (this works for video only)
+      Uri fileUri = getOutputMediaFile(reactContext,MEDIA_TYPE_VIDEO);  // create a file to save the video in specific folder (this works for video only)
       cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, fileUri);
       cameraIntent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, videoQuality);
       if (videoDurationLimit > 0) {

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -7,10 +7,12 @@ import android.graphics.Matrix;
 import android.media.ExifInterface;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
 
 import android.util.Log;
 
@@ -362,7 +364,7 @@ public class MediaUtils {
 
   // Please check this : https://stackoverflow.com/questions/18120775/android-android-provider-mediastore-action-video-capture-return-null-onactivityr
 
-  public static Uri getOutputMediaFile(int type) {
+  public static Uri getOutputMediaFile(Context context, int type) {
     // To be safe, you should check that the SDCard is mounted
 
     if (Environment.getExternalStorageState() != null) {
@@ -389,9 +391,15 @@ public class MediaUtils {
       } else {
         return null;
       }
-
-      return Uri.fromFile(mediaFile);
-    }
+      Uri resultUri;
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        resultUri = Uri.fromFile(mediaFile);
+      } else {
+        resultUri = FileProvider.getUriForFile(context,
+                context.getApplicationContext().getPackageName() + ".provider",
+                mediaFile);
+      }
+      return resultUri;    }
 
     return null;
   }


### PR DESCRIPTION
Fixed the below crash which was hapening in Android 10 

android.os.FileUriExposedException file:///storage/emulated/0/Movies/SMW_VIDEO/VID_20200505_163505.mp4 exposed beyond app through ClipData.Item.getUri() 
    StrictMode.java:1978 android.os.StrictMode.onFileUriExposed
    Uri.java:2371 android.net.Uri.checkFileUriExposed
    ClipData.java:963 android.content.ClipData.prepareToLeaveProcess
    Intent.java:10252 android.content.Intent.prepareToLeaveProcess
    Intent.java:10237 android.content.Intent.prepareToLeaveProcess
    Instrumentation.java:1669 android.app.Instrumentation.execStartActivity
    Activity.java:4651 android.app.Activity.startActivityForResult
    FragmentActivity.java:675 androidx.fragment.app.FragmentActivity.startActivityForResult
    Activity.java:4609 android.app.Activity.startActivityForResult
    FragmentActivity.java:662 androidx.fragment.app.FragmentActivity.startActivityForResult
    ImagePickerModule.java:283 com.imagepicker.ImagePickerModule.launchCamera
    Method.java:-2 java.lang.reflect.Method.invoke
    JavaMethodWrapper.java:372 com.facebook.react.bridge.JavaMethodWrapper.invoke
    JavaModuleWrapper.java:151 com.facebook.react.bridge.JavaModuleWrapper.invoke
    NativeRunnable.java:-2 com.facebook.react.bridge.queue.NativeRunnable.run
    Handler.java:873 android.os.Handler.handleCallback
    Handler.java:99 android.os.Handler.dispatchMessage
    MessageQueueThreadHandler.java:27 com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage
    Looper.java:201 android.os.Looper.loop
    MessageQueueThreadImpl.java:226 com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run
    Thread.java:764 java.lang.Thread.run

